### PR TITLE
Fix - Correct direct color specification bug with "0" and "1" color strings

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,12 @@
+Version 0.2.1
+=============
+**2024-05-08**
+
+🐛 Fix a bug in :class:`~statsplotly.plot_specifiers.color.ColorSpecifier` due to "0" and "1" color strings being interpreted as valid color specifications by `matplotlib`.
+
+🎨 Expose `rgb_string_array_from_colormap` in the :mod:`~statsplotly.utils` module.
+
+
 Version 0.2.0
 =============
 **2024-05-01**

--- a/statsplotly/plot_specifiers/color/__init__.py
+++ b/statsplotly/plot_specifiers/color/__init__.py
@@ -1,6 +1,11 @@
 """This subpackage defines objects and utility methods for color properties."""
 
 from ._core import ColorSpecifier, HistogramColorSpecifier
-from ._utils import set_rgb_alpha
+from ._utils import rgb_string_array_from_colormap, set_rgb_alpha
 
-__all__ = ["ColorSpecifier", "HistogramColorSpecifier", "set_rgb_alpha"]
+__all__ = [
+    "ColorSpecifier",
+    "HistogramColorSpecifier",
+    "rgb_string_array_from_colormap",
+    "set_rgb_alpha",
+]

--- a/statsplotly/plot_specifiers/color/_core.py
+++ b/statsplotly/plot_specifiers/color/_core.py
@@ -20,7 +20,7 @@ from statsplotly.plot_objects.layout import ColorAxis
 from statsplotly.plot_specifiers.common import smart_legend
 from statsplotly.plot_specifiers.layout import BarMode, ColoraxisReference
 
-from ._utils import ColorSystem, compute_colorscale, get_rgb_discrete_array
+from ._utils import ColorSystem, compute_colorscale, rgb_string_array_from_colormap
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ class ColorSpecifier(BaseModel):
     @staticmethod
     def _check_is_direct_color_specification(color_data: pd.Series) -> bool:
         if ColorSpecifier._check_is_discrete_color_data_type(color_data):
-            return all(color_data.map(is_color_like))
+            return all(color_data.replace("0|1", "", regex=True).map(is_color_like))
 
         return False
 
@@ -229,7 +229,7 @@ class ColorSpecifier(BaseModel):
         )
 
     def get_color_hues(self, n_colors: int) -> list[str]:
-        return get_rgb_discrete_array(color_palette=self.color_palette, n_colors=n_colors)
+        return rgb_string_array_from_colormap(color_palette=self.color_palette, n_colors=n_colors)
 
     @classmethod
     def build_from_color_data(

--- a/statsplotly/plot_specifiers/color/_utils.py
+++ b/statsplotly/plot_specifiers/color/_utils.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import plotly
 import seaborn as sns
+from matplotlib.colors import to_rgb
 from numpy.typing import NDArray
 
 from statsplotly import constants
@@ -83,12 +84,15 @@ def cmap_to_array(
             raise UnsupportedColormapError(f"{cmap} is not a supported colormap") from exc
 
 
-def to_rgb_string(numeric_rgb: tuple[float, float, float]) -> str:
-    """Transforms a numeric rgb tuple into a rgb string"""
-    return "rgb" + str(tuple(int(color * 256) for color in numeric_rgb)[:3])
+def to_rgb_string(color_reference: tuple[float, float, float] | str) -> str:
+    """Transforms a color reference into a plotly-compatible rgb string"""
+    if isinstance(color_reference, str):
+        color_reference = to_rgb(color_reference)
+
+    return "rgb" + str(tuple(int(color * 256) for color in color_reference)[:3])
 
 
-def get_rgb_discrete_array(
+def rgb_string_array_from_colormap(
     n_colors: int, color_palette: Cmap_specs | matplotlib.colors.Colormap | None
 ) -> list[str]:
     """Color list/Seaborn color_palette wrapper."""

--- a/statsplotly/utils.py
+++ b/statsplotly/utils.py
@@ -1,5 +1,4 @@
+from statsplotly.plot_specifiers.color import rgb_string_array_from_colormap
 from statsplotly.plot_specifiers.figure import SubplotGridFormatter
 
-__all__ = [
-    "SubplotGridFormatter",
-]
+__all__ = ["rgb_string_array_from_colormap", "SubplotGridFormatter"]

--- a/tests/test_color_specifiers.py
+++ b/tests/test_color_specifiers.py
@@ -21,7 +21,7 @@ EXAMPLE_DIRECT_COLOR_ARRAY = pd.Series(["green", "red", "blue"], name="colors")
 EXAMPLE_VALID_DATETIME_COLOR_DATA = pd.Series(
     pd.to_datetime(("2020-01-01", "2020-01-02", "2020-02-03")), name="color_data"
 )
-EXAMPLE_MAPPED_COLOR_ARRAY = pd.Series(["a", "b", "c"], name="color_ids")
+EXAMPLE_INT_MAPPED_COLOR_ARRAY = pd.Series(["0", "1", "2"], name="color_ids")
 
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -123,27 +123,27 @@ class TestColorSpecifier:
 
         # Mapping
         mapped_color_data = ColorSpecifier.build_from_color_data(
-            EXAMPLE_MAPPED_COLOR_ARRAY
-        ).format_color_data(color_data=EXAMPLE_MAPPED_COLOR_ARRAY)
+            EXAMPLE_INT_MAPPED_COLOR_ARRAY
+        ).format_color_data(color_data=EXAMPLE_INT_MAPPED_COLOR_ARRAY)
         assert all(
             mapped_color_data
-            == EXAMPLE_MAPPED_COLOR_ARRAY.map(
+            == EXAMPLE_INT_MAPPED_COLOR_ARRAY.map(
                 dict(
                     zip(
-                        EXAMPLE_MAPPED_COLOR_ARRAY.dropna().unique(),
-                        range(len(EXAMPLE_MAPPED_COLOR_ARRAY.dropna().unique())),
+                        EXAMPLE_INT_MAPPED_COLOR_ARRAY.dropna().unique(),
+                        range(len(EXAMPLE_INT_MAPPED_COLOR_ARRAY.dropna().unique())),
                         strict=True,
                     )
                 )
             )
         )
         assert (
-            f"{EXAMPLE_MAPPED_COLOR_ARRAY.name} values of type='object' are not continuous type, statsplotly will map it to colormap"
+            f"{EXAMPLE_INT_MAPPED_COLOR_ARRAY.name} values of type='object' are not continuous type, statsplotly will map it to colormap"
             in caplog.text
         )
 
         with pytest.raises(StatsPlotSpecificationError) as excinfo:
-            ColorSpecifier().format_color_data(color_data=EXAMPLE_MAPPED_COLOR_ARRAY)
+            ColorSpecifier().format_color_data(color_data=EXAMPLE_INT_MAPPED_COLOR_ARRAY)
         assert (
             f"No colormap attribute to map discrete data onto, check {ColorSpecifier.__name__} instantiation"
             in str(excinfo.value)


### PR DESCRIPTION
This PR : 
- Fixes a bug with "0" and "1" color data being interpreted as valid color specifications.
- Exposes the `rgb_string_array_from_colormap` function in `statsplotly.utils` module.